### PR TITLE
Add MP3 text-to-speech endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 import uvicorn
 
 from .config.settings import settings
-from .presentation.routers import users
+from .presentation.routers import users, tts
 
 
 def create_app() -> FastAPI:
@@ -28,6 +28,7 @@ def create_app() -> FastAPI:
     
     # Include routers
     app.include_router(users.router)
+    app.include_router(tts.router)
     
     # Root endpoint
     @app.get("/")

--- a/app/presentation/dtos.py
+++ b/app/presentation/dtos.py
@@ -48,3 +48,10 @@ class SuccessResponse(BaseModel):
     message: str
     data: Optional[dict] = None
 
+
+class TtsRequest(BaseModel):
+    """Request DTO for text-to-speech conversion"""
+
+    text: str
+    voice_id: Optional[str] = None
+

--- a/app/presentation/routers/tts.py
+++ b/app/presentation/routers/tts.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from app.config.settings import settings
+from app.presentation.dtos import TtsRequest
+
+router = APIRouter(prefix="/tts", tags=["tts"])
+
+polly_client = boto3.client("polly", region_name=settings.s3.region)
+
+
+@router.post("/", response_class=Response)
+async def text_to_speech(request: TtsRequest) -> Response:
+    """Convert input text to MP3 audio using Amazon Polly."""
+    try:
+        voice_id = request.voice_id or "Mia"
+        result = polly_client.synthesize_speech(
+            Text=request.text,
+            VoiceId=voice_id,
+            OutputFormat="mp3",
+            Engine="neural",
+        )
+        audio_stream = result.get("AudioStream")
+        if audio_stream is None:
+            raise HTTPException(status_code=500, detail="Polly returned no audio stream")
+        audio_bytes = audio_stream.read()
+    except (BotoCoreError, ClientError) as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return Response(content=audio_bytes, media_type="audio/mpeg")


### PR DESCRIPTION
## Summary
- add TtsRequest DTO and new /tts endpoint to synthesize MP3 audio via Amazon Polly
- wire TTS router into FastAPI app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0d21e75e48325a712771f4d5710f4