### PR TITLE
Add test health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 ### Core Endpoints
 - `GET /` - Welcome message
 - `GET /health` - Health check
+- `GET /test/health` - Test health check
 
 ### User Management
 - `POST /users` - Create user

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 import uvicorn
 
 from .config.settings import settings
-from .presentation.routers import users, tts
+from .presentation.routers import users, tts, test
 
 
 def create_app() -> FastAPI:
@@ -29,6 +29,7 @@ def create_app() -> FastAPI:
     # Include routers
     app.include_router(users.router)
     app.include_router(tts.router)
+    app.include_router(test.router)
     
     # Root endpoint
     @app.get("/")

--- a/app/presentation/routers/test.py
+++ b/app/presentation/routers/test.py
@@ -1,0 +1,17 @@
+"""Test endpoints for service diagnostics."""
+
+from fastapi import APIRouter
+
+from app.config.settings import settings
+
+router = APIRouter(prefix="/test", tags=["test"])
+
+
+@router.get("/health")
+async def test_health_check() -> dict[str, str]:
+    """Return service health metadata for testing purposes."""
+    return {
+        "status": "healthy",
+        "service": settings.app_name,
+        "version": settings.app_version,
+    }


### PR DESCRIPTION
## Summary
- add a dedicated /test/health FastAPI router that returns service health metadata
- register the router with the application and document the new endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca0331efe08325a57724b11ec22cfb